### PR TITLE
add Linux support for F2837xD devices

### DIFF
--- a/serial_flash_programmer/CMakeLists.txt
+++ b/serial_flash_programmer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.7.2 FATAL_ERROR)
 
 set(CMAKE_SYSTEM_VERSION 10.0.15063.0 CACHE STRING "" FORCE)
 

--- a/serial_flash_programmer/linux_macros.h
+++ b/serial_flash_programmer/linux_macros.h
@@ -12,6 +12,7 @@
 
 #include <sys/time.h>
 #include <wchar.h>
+#include <stdio.h>
 
 #define TRUE true
 #define FALSE false

--- a/serial_flash_programmer/source/f021_DownloadImage.cpp
+++ b/serial_flash_programmer/source/f021_DownloadImage.cpp
@@ -324,7 +324,7 @@ void loadProgram_checksum(FILE *fh)
 						QUIETPRINT(_T("Error %s\n"), strerror(errno));
 					}
 					dwRead = readf;
-					sendData[0] = buf[0];
+					sendData[1] = buf[0];
 #else
 					ReadFile(file, &sendData[1], 1, &dwRead, NULL);
 #endif

--- a/serial_flash_programmer/source/f021_DownloadImage.cpp
+++ b/serial_flash_programmer/source/f021_DownloadImage.cpp
@@ -373,7 +373,17 @@ void loadProgram_checksum(FILE *fh)
 		dwRead = 0;
 		while (dwRead == 0)
 		{
+#ifdef __linux__
+        			readf = read(fd, &buf, 1);
+					if (readf == -1)
+					{
+						QUIETPRINT(_T("Error %s\n"), strerror(errno));
+					}
+					dwRead = readf;
+					sendData[0] = buf[0];
+#else
 			ReadFile(file, &sendData[0], 1, &dwRead, NULL);
+#endif
 		}
 		//Send ACK as expected
 #ifdef __linux__

--- a/serial_flash_programmer/source/f021_DownloadKernel.cpp
+++ b/serial_flash_programmer/source/f021_DownloadKernel.cpp
@@ -220,7 +220,7 @@ void loadProgram(FILE *fh)
 				QUIETPRINT(_T("Error %s\n"), strerror(errno));
 			}
 			dwRead = readf;
-			//rcvDataH = buf[0];
+			rcvData = buf[0];
 #else
 			ReadFile(file, &rcvData, 1, &dwRead, NULL);
 #endif


### PR DESCRIPTION
people might know this: the F2837xD devices needs to use flash kernel B. One of the differences is that it uses DFU for flashing. This means that it needs to use the loadProgram_checksum() function in f021_DownloadImage.cpp to send and flash the application code. Unfortunately, the initial Linux support for this function was incomplete. This pull request brings Linux support that that function.  It has been tested on embedded Linux (Yocto) on a Variscite VAR-SOM-IMX6.